### PR TITLE
Adjusts Order#add_store_credit_payments

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -21,7 +21,7 @@ module OrderExtensions
       payment_method = Spree::PaymentMethod.find_by_type('Spree::PaymentMethod::StoreCredit')
       raise "Store credit payment method could not be found" unless payment_method
 
-      user.store_credits.order_by_priority.each do |credit|
+      user.store_credits.of_currency(self.currency).order_by_priority.each do |credit|
         break if remaining_total.zero?
         next if credit.amount_remaining.zero?
         next unless credit.valid?

--- a/app/models/spree/store_credit.rb
+++ b/app/models/spree/store_credit.rb
@@ -26,6 +26,7 @@ class Spree::StoreCredit < ActiveRecord::Base
   delegate :email, to: :created_by, prefix: true
 
   scope :order_by_priority, -> { includes(:credit_type).order('spree_store_credit_types.priority ASC') }
+  scope :of_currency, ->(currency) { where(currency: currency) }
 
   before_validation :associate_credit_type
   after_save :store_event


### PR DESCRIPTION
Only store-credits matching the order's currency will be applied. This prevents obscure errors should a customer have a store-credit in another currency--very relevant for multi-currency stores.
