### PR TITLE
Improved Selection of Store Credit Payment Method

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -20,7 +20,7 @@ module OrderExtensions
     remaining_total = outstanding_balance
 
     if user && user.store_credits.any?
-      payment_method = Spree::PaymentMethod.find_by_type('Spree::PaymentMethod::StoreCredit')
+      payment_method = Spree::PaymentMethod.available.find_by_type('Spree::PaymentMethod::StoreCredit')
       raise "Store credit payment method could not be found" unless payment_method
 
       user.store_credits.of_currency(self.currency).order_by_priority.each do |credit|


### PR DESCRIPTION
Under the previous implementation, if a payment method of "Spree::PaymentMethod::StoreCredit" type exists that is inactive, or configured for a different environment, it could be chosen as the payment method for the store-credit payment, and processing the order would fail.

Instead, the payment method selection is now scoped for availability, ensuring that the payment-method selected (if any) can successfully be processed.
